### PR TITLE
Segmentation refactorings and global clustering

### DIFF
--- a/Segment.py
+++ b/Segment.py
@@ -1,0 +1,30 @@
+import os
+from dataclasses import dataclass
+import numpy as np
+from PIL import Image
+
+@dataclass
+class Segment:
+    # Id of the bird
+    class_id: int
+
+    # Id of the image of the bird
+    image_id: int
+
+    # Id of the segment of the image of the bird
+    segment_id: int
+
+    # Raw pixel values of the source patch
+    raw: np.array
+
+    # Feature vector of the image obtained through googlenet. This can easily be
+    # replaced by the bottleneck of an auto encoder to ease clustering.
+    features: np.array
+
+    def default_filename(self):
+        return f'bird_{self.class_id}_image_{self.image_id}_segment_{self.segment_id}.jpg'
+
+    def persist_to_disk(self, folder: str, file_name=None):
+        if file_name is None:
+            file_name = self.default_filename()
+        Image.fromarray(self.raw).save(os.path.join(folder, file_name))

--- a/cluster.py
+++ b/cluster.py
@@ -1,0 +1,22 @@
+import numpy as np
+import os
+from tqdm import tqdm
+from sklearn.cluster import KMeans
+from segmentize import Segment
+
+def _cluster_folder(cluster_id: int) -> str:
+    return f'data/CUB_200_2011/dataset/clusters/{str(cluster_id).rjust(3, "0")}'
+
+def cluster_segments(segments: list[Segment]):
+    print("Clustering...")
+    features = [segment.features for segment in segments]
+    features = np.concatenate(features, 0)
+    k_means = KMeans(n_clusters=250)
+    k_means.fit(features)
+
+    for cluster_id in k_means.labels_:
+        os.makedirs(_cluster_folder(cluster_id), exist_ok=True)
+
+    print("Writing clusters to disk...")
+    for segment, cluster_id in tqdm(zip(segments, k_means.labels_)):
+        segment.persist_to_disk(_cluster_folder(cluster_id))

--- a/main.py
+++ b/main.py
@@ -1,16 +1,12 @@
-# This is a sample Python script.
+from cluster import cluster_segments
+from segmentize import segment_source_images
 
-# Press ⌃R to execute it or replace it with your code.
-# Press Double ⇧ to search everywhere for classes, files, tool windows, actions, and settings.
+# Step 0 is to download the data set and run `crop_images.py` to crop out the
+# parts of the images that actually contain the birds.
 
+# Then we split up each source image into smaller segments from that image and
+# enrich it using features detected by googlenet.
+segments = segment_source_images()
 
-def print_hi(name):
-    # Use a breakpoint in the code line below to debug your script.
-    print(f'Hi, {name}')  # Press ⌘F8 to toggle the breakpoint.
-
-
-# Press the green button in the gutter to run the script.
-if __name__ == '__main__':
-    print_hi('PyCharm')
-
-# See PyCharm help at https://www.jetbrains.com/help/pycharm/
+# Then we cluster the segments based on the detected features
+cluster_segments(segments)

--- a/segmentize.py
+++ b/segmentize.py
@@ -1,13 +1,16 @@
-from skimage.segmentation import felzenszwalb, slic, quickshift, watershed
-from skimage.segmentation import mark_boundaries
-from skimage.util import img_as_float
+import os.path
+import pickle
+
+import torch
+from skimage.segmentation import slic
 from PIL import Image
 import numpy as np
-import matplotlib.pyplot as plt
-import os
-import glob
+from glob import glob
+from torchvision.transforms import transforms
+from tqdm import tqdm
+from Segment import Segment
 
-def _extract_patch(image, mask, average_image_value=117):
+def _extract_segments(image, mask, average_image_value=117):
     mask_expanded = np.expand_dims(mask, -1)
     patch = (mask_expanded * image + (
       1 - mask_expanded) * float(average_image_value) / 255)
@@ -39,38 +42,82 @@ def _return_superpixels(im2arr):
                 if unique:
                     param_masks.append(mask)
         unique_masks.extend(param_masks)
-        superpixels, patches = [], []
+        superpixels, segments = [], []
         while unique_masks:
-            superpixel, patch = _extract_patch(im2arr, unique_masks.pop())
+            superpixel, segment = _extract_segments(im2arr, unique_masks.pop())
             superpixels.append(superpixel)
-            patches.append(patch)
+            segments.append(segment)
 
-        return superpixels, patches
-        # print(segments_slic)
-        # plt.imshow(mark_boundaries(img, segments_slic))
-        # plt.show()
-# dataset, image_numbers, patches = [], [], []
-train_patches_save_path = os.path.join('data/CUB_200_2011', 'dataset/train_patches/')
-path = 'data/CUB_200_2011/dataset/train_crop/*/*'
-index  = 0
-shape = (224, 224)
-for k in glob.glob(path):
-    img = Image.open(k)
-    im2arr = np.array(img.resize(shape, Image.BILINEAR))
-    # Normalize pixel values to between 0 and 1.
-    im2arr = np.float32(im2arr) / 255.0
-    file_name = k.split('/')[-2]
-    print(k)
-    if not os.path.isdir(train_patches_save_path + file_name):
-        os.makedirs(os.path.join(train_patches_save_path, file_name))
-        index = 0
-    image_superpixels, image_patches = _return_superpixels(im2arr)
-    for superpixel, patch in zip(image_superpixels, image_patches):
-        index += 1
-        # print(superpixel)
-        im = superpixel
-            #Image.fromarray((superpixel * 255).astype(np.uint8))
-        im.save(os.path.join(os.path.join(train_patches_save_path, file_name), str(index)+'.jpg'))
-# sdataset, simage_numbers, spatches = \
-#     np.array(dataset), np.array(image_numbers), np.array(patches)
-# print(sdataset.shape)
+        return superpixels, segments
+
+def _images_in_folder(folder_glob):
+    """Iteration logic to load up each image from the birds"""
+    outer_progress = tqdm(glob(folder_glob), position=0, leave=False)
+
+    for folder_path in outer_progress:
+        # Folder names are of the form "001.Black_footed_Albatross"
+        folder_name = folder_path.split("/")[-1]
+        bird_id, bird_name = folder_name.split('.')
+        images = glob(folder_path + '/*.jpg')
+
+        for image_file_path in tqdm(images, desc=bird_name, position=1, leave=False):
+            outer_progress.refresh()
+            # File names are of the form "Black_Footed_Albatross_0001_796111.jpg"
+            file_name = image_file_path.split('/')[-1]
+            suffix = file_name.upper().replace(bird_name.upper() + '_', '')
+            image_id = int(suffix.split('_')[0])
+            yield int(bird_id), image_id, Image.open(image_file_path)
+
+def segment_source_images(
+    source_image_directory='data/CUB_200_2011/dataset/train_crop/*',
+    force_recreation=False,
+    checkpoint_file='data/checkpoints/segments.obj',
+) -> list[Segment]:
+    """
+    :param source_image_directory: Optional path to the cropped image folders
+    :param force_recreation: recreate the checkpoint file instead of reusing it
+    :param checkpoint_file: path to the checkpoint file
+    :return: segments with attached metadata e.g. feature vector obtained from googlenet
+    """
+    if not force_recreation and os.path.isfile(checkpoint_file):
+        print(f'Reading segments from cache ({checkpoint_file})...')
+        with open(checkpoint_file, 'rb') as checkpoint:
+            return pickle.load(checkpoint)
+    else:
+        print('Creating image segments...')
+
+    segments = []
+    model = torch.hub.load('pytorch/vision:v0.9.0', 'googlenet', pretrained=True)
+    model.eval()
+    preprocessing_pipeline = transforms.Compose([
+        transforms.ToTensor(),
+        # Values obtained from Prototree paper
+        transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),
+    ])
+
+    for bird_id, image_id, image in _images_in_folder(source_image_directory):
+        im2arr = np.array(image.resize((224, 224), Image.BILINEAR))
+        # Normalize pixel values to between 0 and 1.
+        im2arr = np.float32(im2arr) / 255.0
+        superpixels, _ = _return_superpixels(im2arr)
+        for i, segment in enumerate(superpixels):
+            segment_data = np.array(segment)
+            segment_tensor = preprocessing_pipeline(segment)
+            with torch.no_grad():
+                mini_batch = segment_tensor.unsqueeze(0)
+                features = model(mini_batch)
+
+            segments.append(Segment(
+                class_id=bird_id,
+                image_id=image_id,
+                segment_id=i,
+                raw=segment_data,
+                features=features
+            ))
+
+    print("Writing checkpoint file...")
+    os.makedirs(os.path.dirname(checkpoint_file), exist_ok=True)
+    with open(checkpoint_file, 'wb') as checkpoint:
+        pickle.dump(segments, checkpoint)
+
+    return segments


### PR DESCRIPTION
Now the segmentation and interpretation by googlenet is done in one go. We can keep all data in memory, so there is no need to write the segments to disk now.

"Checkpoint" files are created, so that we do not always have to redo the segmentation and are able to quickly load the dataset into memory (takes around a second or so).

If you want to speed up the process (at least I did it), you can just rename the `dataset/train_crop` to `dataset/train_crop_all` and create a new `dataset/train_crop` folder, that only contains the first 10 birds or so. Then the segmentation takes a few minutes instead of 2 hours.

Also you might need to install `tqdm`, which I used to create some progress bars (they also roughly estimate how long a long running task, e.g. the segmentation, will take which is nice)